### PR TITLE
Support SLSAv02 in slsa verifiers

### DIFF
--- a/slsa/slsa-build-point.json
+++ b/slsa/slsa-build-point.json
@@ -1,7 +1,8 @@
 {
     "id": "slsa-build-point",
     "meta": {
-        "description": "Ensures an artifact was built from a specific repository and commit"
+        "description": "Ensures an artifact was built from a specific repository and commit",
+        "assert_mode": "OR"
     },
     "context": {
         "buildPoint" : {
@@ -26,6 +27,20 @@
                 }
             },
             "code": "(outputs.externalParamSource == context.buildPoint || (outputs.externalParamSource.startsWith(context.buildPoint + '@') && context.buildPointAllowRepo) ) || outputs.foundInResolvedDependencies ",
+            "assessment": { "message": "Expected build point found: {{ .Context.buildPoint  }}" },
+            "error": {
+                "message": "Build point mismatch",
+                "guidance": "The attested build point does not match the expected commit"
+            }
+        },
+        {
+            "predicates": { "types": ["https://slsa.dev/provenance/v0.2"] },
+            "outputs": {
+                "foundInMaterials": {
+                    "code": "has(predicate.data.materials) && context.buildPoint.contains(':') ? predicate.data.materials.exists(d, context.buildPoint.split(':')[0] in d.digest && d.digest[context.buildPoint.split(':')[0]] == context.buildPoint.split(':')[1]) : false"
+                }
+            },
+            "code": "outputs.foundInMaterials ",
             "assessment": { "message": "Expected build point found: {{ .Context.buildPoint  }}" },
             "error": {
                 "message": "Build point mismatch",

--- a/slsa/slsa-build-type.json
+++ b/slsa/slsa-build-type.json
@@ -1,7 +1,8 @@
 {
     "id": "slsa-build-type",
     "meta": {
-        "description": "Ensures an artifact was built from a specified repository and commit"
+        "description": "Ensures an artifact was built from a specified repository and commit",
+        "assert_mode": "OR"
     },
     "context": {
         "buildType" : {
@@ -15,6 +16,20 @@
             "outputs": {
                 "buildType": {
                     "code": "has(predicates[0].data.buildDefinition) ? (has(predicates[0].data.buildDefinition.buildType) ? predicates[0].data.buildDefinition.buildType : '' ) : '' "
+                }
+            },
+            "code": "outputs.buildType == context.buildType || outputs.buildType.startsWith(context.buildType + '@')",
+            "assessment": { "message": "Expected buildType found: {{ .Outputs.buildType  }}" },
+            "error": {
+                "message": "BuildType mismatch",
+                "guidance": "The attested build type ({{ .Outputs.buildType }}) does not match the expected identifier"
+            }
+        },
+        {
+            "predicates": { "types": ["https://slsa.dev/provenance/v0.2"] },
+            "outputs": {
+                "buildType": {
+                    "code": "has(predicates[0].data.buildType) ? predicates[0].data.buildType : '' "
                 }
             },
             "code": "outputs.buildType == context.buildType || outputs.buildType.startsWith(context.buildType + '@')",

--- a/slsa/slsa-builder-id.json
+++ b/slsa/slsa-builder-id.json
@@ -1,7 +1,8 @@
 {
     "id": "slsa-builder-id",
     "meta": {
-        "description": "Ensures an artifact was built by a specific builder"
+        "description": "Ensures an artifact was built by a specific builder",
+        "assert_mode": "OR"
     },
     "context": {
         "builderId" : {
@@ -15,6 +16,20 @@
             "outputs": {
                 "builderId": {
                     "code": "has(predicates[0].data.runDetails) ? (has(predicates[0].data.runDetails.builder) ? predicates[0].data.runDetails.builder.id : '' ) : '' "
+                }
+            },
+            "code": "outputs.builderId == context.builderId || outputs.builderId.startsWith(context.builderId + '@')",
+            "assessment": { "message": "Authorized builder ID detected" },
+            "error": {
+                "message": "Builder identifier mismatch",
+                "guidance": "The attestation builder does not match the context defined builder (want {{ .Context.builderId }} got {{ .Outputs.builderId }})"
+            }
+        },
+        {
+            "predicates": { "types": ["https://slsa.dev/provenance/v0.2"] },
+            "outputs": {
+                "builderId": {
+                    "code": "has(predicates[0].data.builder) ? (has(predicates[0].data.builder.id) ? predicates[0].data.builder.id : '' ) : '' "
                 }
             },
             "code": "outputs.builderId == context.builderId || outputs.builderId.startsWith(context.builderId + '@')",


### PR DESCRIPTION
This pull request updates the SLSA assertion JSON files to improve compatibility with SLSA Provenance v0.2 and enhance assertion flexibility. The main changes include adding new predicate checks for v0.2, adjusting assertion logic to allow for more flexible matching, and introducing an `assert_mode` to support OR-based assertions.

Enhancements for SLSA Provenance v0.2 compatibility:

* Added new predicate checks for SLSA Provenance v0.2 in `slsa-builder-id.json`, `slsa-build-type.json`, and `slsa-build-point.json`, enabling extraction and validation of relevant fields from v0.2 attestation data. [[1]](diffhunk://#diff-7e572f169993ed6de10685d6fa3ed8e7d4dceb61a8e86c2ca9321bf19ef89cb3R27-R40) [[2]](diffhunk://#diff-9fbe856ea5d21f76805aa13bd5a8c5163b52021177c37f7a89d68dd677e8fa80R27-R40) [[3]](diffhunk://#diff-e84532d7821170c555fca25b354a1063765f67cc1057ef8687ec493b257d4709R35-R48)

Improved assertion flexibility:

* Introduced `assert_mode: "OR"` in the `meta` section of all three assertion JSON files, allowing assertions to pass if any of the defined checks succeed. [[1]](diffhunk://#diff-7e572f169993ed6de10685d6fa3ed8e7d4dceb61a8e86c2ca9321bf19ef89cb3L4-R5) [[2]](diffhunk://#diff-9fbe856ea5d21f76805aa13bd5a8c5163b52021177c37f7a89d68dd677e8fa80L4-R5) [[3]](diffhunk://#diff-e84532d7821170c555fca25b354a1063765f67cc1057ef8687ec493b257d4709L4-R5)
* Updated assertion logic in the new v0.2 predicate checks to allow matches on exact values or values with version suffixes (e.g., `builderId@version` or `buildType@version`). [[1]](diffhunk://#diff-7e572f169993ed6de10685d6fa3ed8e7d4dceb61a8e86c2ca9321bf19ef89cb3R27-R40) [[2]](diffhunk://#diff-9fbe856ea5d21f76805aa13bd5a8c5163b52021177c37f7a89d68dd677e8fa80R27-R40)

Expanded build point validation:

* Enhanced `slsa-build-point.json` to check for the expected build point in the attestation's `materials` field, supporting more robust validation of provenance data.