### PR TITLE
Fix correct CEL expressions in individual OSPS policies

### DIFF
--- a/sbom/sbom-contains-changelog.json
+++ b/sbom/sbom-contains-changelog.json
@@ -12,7 +12,7 @@
             },
             "outputs": {
                 "files": {
-                    "code": "sboms[0].get_node_list().get_nodes().filter(n, (n.name == 'CHANGELOG' || n.name == 'changelog.txt' ))"
+                    "code": "sboms[0].get_node_list().get_nodes().filter(n, (n.name == 'CHANGELOG' || n.name == 'changelog.txt' || n.name == 'CHANGELOG.md' || n.name == 'CHANGELOG.rst' || n.name == 'CHANGELOG.txt'))"
                 }
             },
             "assessment": {

--- a/sbom/sbom-licenses-are-foss.json
+++ b/sbom/sbom-licenses-are-foss.json
@@ -12,7 +12,7 @@
             },
             "outputs": {
                 "licenses": {
-                    "code": "sboms[0].get_node_list().get_nodes().map(n, size(n.licenses) > 0, n.licenses)"
+                    "code": "sboms[0].get_node_list().get_nodes().filter(n, size(n.licenses) > 0).map(n, n.licenses[0])"
                 },
                 "licenses_test": {
                     "code": "['AFL-2.1', 'Apache-2.0']"

--- a/security-insights/assessments.json
+++ b/security-insights/assessments.json
@@ -12,7 +12,7 @@
             "code": "size(outputs.assessments) > 0",
             "outputs": {
                 "assessments": {
-                    "code": "has(predicates[0].data.security) ? (has(predicates[0].data.security.assessments) ? predicates[0].data.security.assessments : {} ) : {} "
+                    "code": "has(predicates[0].data.repository) && has(predicates[0].data.repository.security) && has(predicates[0].data.repository.security.assessments) ? predicates[0].data.repository.security.assessments : {}"
                 }
             },
             "assessment": {

--- a/security-insights/dependency-policy.json
+++ b/security-insights/dependency-policy.json
@@ -12,7 +12,7 @@
             "code": "outputs.deppolicy != '' ",
             "outputs": {
                 "deppolicy": {
-                    "code": "has(predicates[0].data.repository) ? (has(predicates[0].data.repository.documentation) ? (has(predicates[0].data.repository.documentation.dependency_management_policy) ? predicates[0].data.repository.documentation.dependency_management_policy : '') : '') : '' "
+                    "code": "has(predicates[0].data.repository) ? (has(predicates[0].data.repository.documentation) ? (predicates[0].data.repository.documentation.exists(k, k == 'dependency-management-policy') ? predicates[0].data.repository.documentation['dependency-management-policy'] : '') : '') : '' "
                 }
             },
             "assessment": {

--- a/security-insights/signature-verify.json
+++ b/security-insights/signature-verify.json
@@ -9,7 +9,7 @@
             "code": "outputs['verify'] != '' ",
             "outputs": {
                 "verify": {
-                    "code": "has(predicates[0].project) ? (has(predicates[0].project.documentation) ? ('signature-verification' in predicates[0].project.documentation ? predicates[0].project.documentation['signature-verification'] : '' ) : '' ) : '' "
+                    "code": "has(predicates[0].data.project) ? (has(predicates[0].data.project.documentation) ? ('signature-verification' in predicates[0].data.project.documentation ? predicates[0].data.project.documentation['signature-verification'] : '' ) : '' ) : '' "
                 }
             },
             "predicates": {


### PR DESCRIPTION
Five policy bug fixes found while implementing the OSPS baseline evidence-chain PolicySet:

- sbom/sbom-contains-changelog.json: add CHANGELOG.md, CHANGELOG.rst, and CHANGELOG.txt filename variants (filter only matched CHANGELOG and changelog.txt, failing repos that use the common .md extension)

- sbom/sbom-licenses-are-foss.json: flatten output from list<list<string>> to list<string> by using filter().map(n, n.licenses[0]) instead of map(n, filter, n.licenses), so the all() tenet comparison works correctly

- security-insights/assessments.json: correct CEL path from data.security to data.repository.security to match Security Insights v2 structure

- security-insights/dependency-policy.json: use bracket notation for the hyphenated key dependency-management-policy; dot notation silently returned empty string on every repo

- security-insights/signature-verify.json: fix predicates[0].project path to predicates[0].data.project; AMPEL wraps all predicate content under .data so the has() guard always returned false