### PR TITLE
Accept new namespaced predicateTypes for snappy github specs

### DIFF
--- a/snappy/branch-branch-protection.json
+++ b/snappy/branch-branch-protection.json
@@ -8,7 +8,7 @@
         {
             "code": "size(predicates) > 0",
             "predicates": {
-                "types": ["http://github.com/carabiner-dev/snappy/specs/branch-rules.yaml"]
+                "types": ["http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml", "http://github.com/carabiner-dev/snappy/specs/branch-rules.yaml"]
             },
             "assessment": {
                 "message": "Found attested branch protection metadata"
@@ -18,7 +18,7 @@
             "id": "01",
             "code": "has(predicates[0].data.values) ? predicates[0].data.values.exists(rule, rule.type == \"non_fast_forward\") : false",
             "predicates": {
-                "types": ["http://github.com/carabiner-dev/snappy/specs/branch-rules.yaml"]
+                "types": ["http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml", "http://github.com/carabiner-dev/snappy/specs/branch-rules.yaml"]
             },
             "assessment": {
                 "message": "Force pushing is disabled on default branch"
@@ -32,7 +32,7 @@
             "id": "02",
             "code": "has(predicates[0].data.values) ? predicates[0].data.values.exists(rule, rule.type == \"deletion\") : false",
             "predicates": {
-                "types": ["http://github.com/carabiner-dev/snappy/specs/branch-rules.yaml"]
+                "types": ["http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml", "http://github.com/carabiner-dev/snappy/specs/branch-rules.yaml"]
             },
             "assessment": {
                 "message": "Branch deletion is disabled on default branch"

--- a/snappy/branch-status-checks.json
+++ b/snappy/branch-status-checks.json
@@ -8,7 +8,7 @@
             "id": "01",
             "code": "has(predicates[0].data.values) ? predicates[0].data.values.exists(rule, rule.type == \"required_status_checks\") : false",
             "predicates": {
-                "types": ["http://github.com/carabiner-dev/snappy/specs/branch-rules.yaml"]
+                "types": ["http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml", "http://github.com/carabiner-dev/snappy/specs/branch-rules.yaml"]
             },
             "assessment": {
                 "message": "Status checks enforced"

--- a/snappy/org-exists.json
+++ b/snappy/org-exists.json
@@ -6,7 +6,7 @@
     "tenets": [
         {
             "id": "01",
-            "predicates": { "types": ["http://github.com/carabiner-dev/snappy/specs/org.yaml"] },
+            "predicates": { "types": ["http://github.com/carabiner-dev/snappy/specs/github/org.yaml", "http://github.com/carabiner-dev/snappy/specs/org.yaml"] },
             "code": "true",
             "assessment": { "message": "Attested GitHub organization data found" }
         }

--- a/snappy/repo-issues.json
+++ b/snappy/repo-issues.json
@@ -7,7 +7,10 @@
         {
             "code": "size(predicates) > 0",
             "predicates": {
-                "types": ["http://github.com/carabiner-dev/snappy/specs/repo.yaml"]
+                "types": [
+                    "http://github.com/carabiner-dev/snappy/specs/github/repo.yaml",
+                    "http://github.com/carabiner-dev/snappy/specs/repo.yaml"
+                ]
             },
             "assessment": {
                 "message": "Found attested repository data"
@@ -17,7 +20,10 @@
             "id": "01",
             "code": "outputs[\"issues\"]",
             "predicates": {
-                "types": ["http://github.com/carabiner-dev/snappy/specs/repo.yaml"]
+                "types": [
+                    "http://github.com/carabiner-dev/snappy/specs/github/repo.yaml",
+                    "http://github.com/carabiner-dev/snappy/specs/repo.yaml"
+                ]
             },
             "outputs": {
                 "issues": {

--- a/snappy/repo-public-git.json
+++ b/snappy/repo-public-git.json
@@ -8,7 +8,10 @@
             "id": "01",
             "code": "outputs[\"public\"]",
             "predicates": {
-                "types": ["http://github.com/carabiner-dev/snappy/specs/repo.yaml"]
+                "types": [
+                    "http://github.com/carabiner-dev/snappy/specs/github/repo.yaml",
+                    "http://github.com/carabiner-dev/snappy/specs/repo.yaml"
+                ]
             },
             "outputs": {
                 "public": {
@@ -27,7 +30,10 @@
             "id": "02",
             "code": "outputs[\"git\"] != ''",
             "predicates": {
-                "types": ["http://github.com/carabiner-dev/snappy/specs/repo.yaml"]
+                "types": [
+                    "http://github.com/carabiner-dev/snappy/specs/github/repo.yaml",
+                    "http://github.com/carabiner-dev/snappy/specs/repo.yaml"
+                ]
             },
             "outputs": {
                 "git": {


### PR DESCRIPTION
snappy namespaced specs by provider (specs/github/, specs/gitlab/) when GitLab support was added. All 5 snappy policies in the repo were still expecting the old flat paths, causing attestationsgenerated by current snappy builtins to be invisible to policies.

Accept both the new namespaced and old paths for backward compatibility.