### PR TITLE
Add three more osv policies

### DIFF
--- a/osv/.ptests.yaml
+++ b/osv/.ptests.yaml
@@ -12,3 +12,72 @@ tests:
     subject: "sha256:7950b24d06407456038435a2a3dfd99531ae8e35940b6fc4dae3cd6f1b504585"
     attestations:
       - ../testdata/osv/critical.intoto.json
+
+  # The same critical report passes once the threshold is raised above its
+  # highest score, proving cvssThreshold is user-configurable.
+  - name: critical-passes-when-threshold-raised
+    policy: osv-no-critical.hjson
+    expect: PASS
+    subject: "sha256:7950b24d06407456038435a2a3dfd99531ae8e35940b6fc4dae3cd6f1b504585"
+    attestations:
+      - ../testdata/osv/critical.intoto.json
+    context:
+      - name: cvssThreshold
+        value: 10
+
+  # osv-no-known-exploited: fails on any KEV vulnerability.
+  - name: no-known-exploited-passes-without-kev
+    policy: osv-no-known-exploited.hjson
+    expect: PASS
+    subject: "sha256:7950b24d06407456038435a2a3dfd99531ae8e35940b6fc4dae3cd6f1b504585"
+    attestations:
+      - ../testdata/osv/enriched-low-risk.intoto.json
+
+  - name: no-known-exploited-fails-with-kev
+    policy: osv-no-known-exploited.hjson
+    expect: FAIL
+    subject: "sha256:7950b24d06407456038435a2a3dfd99531ae8e35940b6fc4dae3cd6f1b504585"
+    attestations:
+      - ../testdata/osv/enriched-high-risk.intoto.json
+
+  # osv-no-fixable: fails when a vulnerability already has a fix available.
+  - name: no-fixable-passes-when-nothing-is-fixed
+    policy: osv-no-fixable.hjson
+    expect: PASS
+    subject: "sha256:7950b24d06407456038435a2a3dfd99531ae8e35940b6fc4dae3cd6f1b504585"
+    attestations:
+      - ../testdata/osv/enriched-low-risk.intoto.json
+
+  - name: no-fixable-fails-when-a-fix-is-available
+    policy: osv-no-fixable.hjson
+    expect: FAIL
+    subject: "sha256:7950b24d06407456038435a2a3dfd99531ae8e35940b6fc4dae3cd6f1b504585"
+    attestations:
+      - ../testdata/osv/enriched-high-risk.intoto.json
+
+  # osv-max-epss: fails on any vulnerability at or above the EPSS threshold.
+  - name: max-epss-passes-with-low-epss
+    policy: osv-max-epss.hjson
+    expect: PASS
+    subject: "sha256:7950b24d06407456038435a2a3dfd99531ae8e35940b6fc4dae3cd6f1b504585"
+    attestations:
+      - ../testdata/osv/enriched-low-risk.intoto.json
+
+  - name: max-epss-fails-with-high-epss
+    policy: osv-max-epss.hjson
+    expect: FAIL
+    subject: "sha256:7950b24d06407456038435a2a3dfd99531ae8e35940b6fc4dae3cd6f1b504585"
+    attestations:
+      - ../testdata/osv/enriched-high-risk.intoto.json
+
+  # The high-EPSS report passes once the threshold is raised above its score,
+  # proving epssThreshold is user-configurable.
+  - name: max-epss-passes-when-threshold-raised
+    policy: osv-max-epss.hjson
+    expect: PASS
+    subject: "sha256:7950b24d06407456038435a2a3dfd99531ae8e35940b6fc4dae3cd6f1b504585"
+    attestations:
+      - ../testdata/osv/enriched-high-risk.intoto.json
+    context:
+      - name: epssThreshold
+        value: "0.95"

--- a/osv/osv-max-epss.hjson
+++ b/osv/osv-max-epss.hjson
@@ -1,0 +1,48 @@
+{
+  # osv-max-epss
+  #
+  # Fails when an attested OSV report contains a vulnerability whose EPSS score
+  # (probability of exploitation in the next 30 days, 0.0-1.0) is at or above a
+  # configurable threshold. Uses the osv CEL plugin's osv.epss, which reads the
+  # `epss` enrichment written by the scanner.
+  id: osv-max-epss
+  meta: {
+    description: "Fails when an attested OSV report contains a vulnerability with an EPSS score at or above the threshold (default 0.5)"
+    # Requires the osv CEL plugin. Engines that lack it skip this policy
+    # (with --skip-unsupported-runtime) rather than failing to compile it.
+    runtime: "cel@v1?plugin:osv=v1"
+  }
+  context: {
+    epssThreshold: {
+      required: false
+      # EPSS is a 0.0-1.0 probability, so it is carried as a string and parsed
+      # with double() below (ampel context values are only bool/string/int).
+      type: "string"
+      default: "0.5"
+      description: "EPSS score (0.0-1.0) at or above which a vulnerability fails the policy. Defaults to 0.5."
+    }
+  }
+  tenets: [
+    {
+      predicates: {
+        types: [
+          "https://ossf.github.io/osv-schema/results@v1"
+          "https://ossf.github.io/osv-schema/results@v1.6.7"
+        ]
+      }
+      outputs: {
+        likelyExploited: {
+          code: "osv.vulns(predicate).filter(v, osv.epss(v) >= double(context.epssThreshold)).map(v, v.id)"
+        }
+      }
+      code: "size(outputs.likelyExploited) == 0"
+      assessment: {
+        message: "Attested OSV report contains no vulnerabilities at or above the EPSS threshold"
+      }
+      error: {
+        message: "Attested OSV report contains vulnerabilities at or above the EPSS threshold: {{ .Outputs.likelyExploited }}"
+        guidance: "These vulnerabilities are likely to be exploited (high EPSS) — prioritize remediation, or raise the epssThreshold context value"
+      }
+    }
+  ]
+}

--- a/osv/osv-no-critical.hjson
+++ b/osv/osv-no-critical.hjson
@@ -1,17 +1,26 @@
 {
   # osv-no-critical
   #
-  # Fails when an attested OSV report contains a critical (CVSS >= 9.0)
-  # vulnerability. Showcases the osv CEL plugin: osv.vulns flattens the nested
-  # results -> packages -> vulnerabilities, and osv.cvss reads the numeric CVSS
-  # base score from each finding's severity vector — a threshold that is
-  # impractical to express in raw CEL.
+  # Fails when an attested OSV report contains a vulnerability whose CVSS base
+  # score is at or above a configurable threshold (the `cvssThreshold` context
+  # value, default 9 — "critical"). Showcases the osv CEL plugin: osv.vulns
+  # flattens the nested results -> packages -> vulnerabilities, and osv.cvss
+  # reads the numeric CVSS base score from each finding's severity vector — a
+  # threshold that is impractical to express in raw CEL.
   id: osv-no-critical
   meta: {
-    description: "Ensures an attested OSV report contains no critical (CVSS >= 9.0) vulnerabilities"
+    description: "Ensures an attested OSV report contains no vulnerability at or above the CVSS threshold (default 9)"
     # Requires the osv CEL plugin. Engines that lack it skip this policy
     # (with --skip-unsupported-runtime) rather than failing to compile it.
     runtime: "cel@v1?plugin:osv=v1"
+  }
+  context: {
+    cvssThreshold: {
+      required: false
+      type: "int"
+      default: 9
+      description: "Minimum CVSS base score (0-10) that counts as a failing vulnerability. Defaults to 9 (critical)."
+    }
   }
   tenets: [
     {
@@ -22,17 +31,17 @@
         ]
       }
       outputs: {
-        criticalVulns: {
-          code: "osv.vulns(predicate).filter(v, osv.cvss(v) >= 9.0).map(v, v.id)"
+        flaggedVulns: {
+          code: "osv.vulns(predicate).filter(v, osv.cvss(v) >= double(context.cvssThreshold)).map(v, v.id)"
         }
       }
-      code: "size(outputs.criticalVulns) == 0"
+      code: "size(outputs.flaggedVulns) == 0"
       assessment: {
-        message: "Attested OSV report has no critical vulnerabilities"
+        message: "Attested OSV report has no vulnerability at or above the CVSS threshold"
       }
       error: {
-        message: "Attested OSV report contains critical vulnerabilities: {{ .Outputs.criticalVulns }}"
-        guidance: "Remediate or suppress the critical (CVSS >= 9.0) vulnerabilities before this policy can pass"
+        message: "Attested OSV report contains vulnerabilities at or above the CVSS threshold: {{ .Outputs.flaggedVulns }}"
+        guidance: "Remediate or suppress the flagged vulnerabilities, or raise the cvssThreshold context value"
       }
     }
   ]

--- a/osv/osv-no-fixable.hjson
+++ b/osv/osv-no-fixable.hjson
@@ -1,0 +1,37 @@
+{
+  # osv-no-fixable
+  #
+  # Fails when an attested OSV report contains a vulnerability that already has
+  # a fixed version available. Uses the osv CEL plugin's osv.isFixed, which
+  # reports whether a finding's affected ranges declare a `fixed` event.
+  id: osv-no-fixable
+  meta: {
+    description: "Fails when an attested OSV report contains a vulnerability that already has a fix available"
+    # Requires the osv CEL plugin. Engines that lack it skip this policy
+    # (with --skip-unsupported-runtime) rather than failing to compile it.
+    runtime: "cel@v1?plugin:osv=v1"
+  }
+  tenets: [
+    {
+      predicates: {
+        types: [
+          "https://ossf.github.io/osv-schema/results@v1"
+          "https://ossf.github.io/osv-schema/results@v1.6.7"
+        ]
+      }
+      outputs: {
+        fixable: {
+          code: "osv.vulns(predicate).filter(v, osv.isFixed(v)).map(v, v.id)"
+        }
+      }
+      code: "size(outputs.fixable) == 0"
+      assessment: {
+        message: "Attested OSV report contains no vulnerabilities with an available fix"
+      }
+      error: {
+        message: "Attested OSV report contains vulnerabilities with an available fix: {{ .Outputs.fixable }}"
+        guidance: "These vulnerabilities already have fixed versions — upgrade the affected packages to remediate them"
+      }
+    }
+  ]
+}

--- a/osv/osv-no-known-exploited.hjson
+++ b/osv/osv-no-known-exploited.hjson
@@ -1,0 +1,37 @@
+{
+  # osv-no-known-exploited
+  #
+  # Fails when an attested OSV report contains a known-exploited vulnerability
+  # (one flagged in CISA's KEV catalog). Uses the osv CEL plugin's osv.isKEV,
+  # which reads the `known_exploited` enrichment written by the scanner.
+  id: osv-no-known-exploited
+  meta: {
+    description: "Fails when an attested OSV report contains a known-exploited (KEV) vulnerability"
+    # Requires the osv CEL plugin. Engines that lack it skip this policy
+    # (with --skip-unsupported-runtime) rather than failing to compile it.
+    runtime: "cel@v1?plugin:osv=v1"
+  }
+  tenets: [
+    {
+      predicates: {
+        types: [
+          "https://ossf.github.io/osv-schema/results@v1"
+          "https://ossf.github.io/osv-schema/results@v1.6.7"
+        ]
+      }
+      outputs: {
+        exploited: {
+          code: "osv.vulns(predicate).filter(v, osv.isKEV(v)).map(v, v.id)"
+        }
+      }
+      code: "size(outputs.exploited) == 0"
+      assessment: {
+        message: "Attested OSV report contains no known-exploited vulnerabilities"
+      }
+      error: {
+        message: "Attested OSV report contains known-exploited vulnerabilities: {{ .Outputs.exploited }}"
+        guidance: "Known-exploited (KEV) vulnerabilities are being exploited in the wild — remediate them immediately"
+      }
+    }
+  ]
+}

--- a/testdata/osv/enriched-high-risk.intoto.json
+++ b/testdata/osv/enriched-high-risk.intoto.json
@@ -1,0 +1,51 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "artifact",
+      "digest": {
+        "sha256": "7950b24d06407456038435a2a3dfd99531ae8e35940b6fc4dae3cd6f1b504585"
+      }
+    }
+  ],
+  "predicateType": "https://ossf.github.io/osv-schema/results@v1",
+  "predicate": {
+    "date": "2026-07-11T00:00:00Z",
+    "results": [
+      {
+        "source": { "path": "go.mod", "type": "lockfile" },
+        "packages": [
+          {
+            "package": { "name": "github.com/example/vuln", "ecosystem": "Go" },
+            "vulnerabilities": [
+              {
+                "id": "CVE-2026-9001",
+                "summary": "known-exploited, fixed, high-EPSS example",
+                "severity": [
+                  { "type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H" }
+                ],
+                "affected": [
+                  {
+                    "package": { "name": "github.com/example/vuln", "ecosystem": "Go", "purl": "pkg:golang/github.com/example/vuln@1.0.0" },
+                    "ranges": [
+                      { "type": "ECOSYSTEM", "events": [ { "introduced": "0" }, { "fixed": "2.0.0" } ] }
+                    ]
+                  }
+                ],
+                "references": [
+                  { "type": "ADVISORY", "url": "https://github.com/advisories/GHSA-9001" }
+                ],
+                "database_specific": {
+                  "severity": "CRITICAL",
+                  "epss": 0.9,
+                  "known_exploited": true,
+                  "cwe_ids": [ "CWE-79" ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/testdata/osv/enriched-low-risk.intoto.json
+++ b/testdata/osv/enriched-low-risk.intoto.json
@@ -1,0 +1,46 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "artifact",
+      "digest": {
+        "sha256": "7950b24d06407456038435a2a3dfd99531ae8e35940b6fc4dae3cd6f1b504585"
+      }
+    }
+  ],
+  "predicateType": "https://ossf.github.io/osv-schema/results@v1",
+  "predicate": {
+    "date": "2026-07-11T00:00:00Z",
+    "results": [
+      {
+        "source": { "path": "go.mod", "type": "lockfile" },
+        "packages": [
+          {
+            "package": { "name": "github.com/example/minor", "ecosystem": "Go" },
+            "vulnerabilities": [
+              {
+                "id": "CVE-2026-9002",
+                "summary": "not exploited, unfixed, low-EPSS example",
+                "severity": [
+                  { "type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N" }
+                ],
+                "affected": [
+                  {
+                    "package": { "name": "github.com/example/minor", "ecosystem": "Go", "purl": "pkg:golang/github.com/example/minor@1.0.0" },
+                    "ranges": [
+                      { "type": "ECOSYSTEM", "events": [ { "introduced": "0" } ] }
+                    ]
+                  }
+                ],
+                "database_specific": {
+                  "severity": "MEDIUM",
+                  "epss": 0.02
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This pull request adds several new OSV (Open Source Vulnerabilities) policy files, test data, and comprehensive policy tests to support richer vulnerability filtering in the policy engine. The main improvements are the introduction of configurable policies for failing on critical, fixable, known-exploited, and high-EPSS vulnerabilities, along with new test cases and enriched test data to validate these policies.

**New and updated OSV policies:**

* [`osv/osv-no-critical.hjson`](diffhunk://#diff-3d57233eb49fa2f9d1a16305a77f3062a61a3e29fb108f81db134f2f37ed6707L4-R24): Updated to allow a configurable `cvssThreshold` for what counts as a critical vulnerability, making the policy more flexible. [[1]](diffhunk://#diff-3d57233eb49fa2f9d1a16305a77f3062a61a3e29fb108f81db134f2f37ed6707L4-R24) [[2]](diffhunk://#diff-3d57233eb49fa2f9d1a16305a77f3062a61a3e29fb108f81db134f2f37ed6707L25-R44)
* [`osv/osv-no-known-exploited.hjson`](diffhunk://#diff-d1d8835c18740ae839601f0a0be12874739c2919122c6a5e979fe0730ddea245R1-R37): Added a policy that fails if any known-exploited (KEV) vulnerabilities are present.
* [`osv/osv-no-fixable.hjson`](diffhunk://#diff-841dc8ce9de298a64daa9f44e6293d140d3011b032706939d5591dee08133a37R1-R37): Added a policy that fails when any vulnerability with an available fix is found.
* [`osv/osv-max-epss.hjson`](diffhunk://#diff-18bc02944a88412e1e8b493a1e82aeebdd2ba581f2235fdf036e3d0fb8fac392R1-R48): Added a policy that fails if any vulnerability has an EPSS (Exploit Prediction Scoring System) score at or above a configurable threshold.

**Test data and policy tests:**

* `testdata/osv/enriched-high-risk.intoto.json` and `testdata/osv/enriched-low-risk.intoto.json`: Added new enriched OSV attestation files simulating high-risk and low-risk vulnerabilities, including fields for CVSS, EPSS, fixability, and known-exploited status. [[1]](diffhunk://#diff-40e23ea0285aadfd52912e4aacdc758e95d86e5cb5d6683d8cbb1bfe28618b86R1-R51) [[2]](diffhunk://#diff-a3b4a71f6012306adb27c9a853a98eb683691ed8106b94e4b44f7c9d53865b03R1-R46)
* [`osv/.ptests.yaml`](diffhunk://#diff-89eb9b727c751b97f43f4bd770663ecd5bc8c35f6a570f506d079e9c7a5e36dbR15-R83): Introduced comprehensive test cases for all new and updated policies, including tests for threshold configurability and expected PASS/FAIL outcomes.

These changes together enable more granular and realistic vulnerability policy enforcement and testing in the project.