### PR TITLE
Add gitsign identity policy

### DIFF
--- a/gitsign/gitsign-commit-signature.hjson
+++ b/gitsign/gitsign-commit-signature.hjson
@@ -1,0 +1,75 @@
+{
+    id: gitsign-commit-signature
+
+    meta: {
+        description:
+            '''
+            # Gitsign Commit Signature Verification
+
+            Passes when the subject git commit carries a verified gitsign
+            (sigstore) signature from an accepted signer.
+
+            The carabiner gitsign collector reads the commit's sigstore
+            signature, cryptographically verifies it (the Fulcio certificate
+            chain and Rekor transparency-log inclusion), and emits a gitsign
+            commit attestation (`https://gitsign.sigstore.dev/predicate/git/v0.1`)
+            carrying the verified signer identity. AMPEL matches that signer
+            against the identities supplied at verification time (`--signer`) or
+            declared in a policy `identities` block, and only admits attestations
+            from an accepted signer. This tenet then asserts that at least one
+            such attestation is present **and** that its matched signer identity
+            is set and is a sigstore identity — so a signer must be pinned (an
+            empty match, or a key/reference identity, is rejected).
+
+            ## Verifying
+
+            The signer identity is enforced by AMPEL, not by the tenet code, so
+            supply the expected signer with `--signer`:
+
+            ```
+            ampel verify --subject-hash sha1:<commit-sha> \
+                -c gitsign:git+https://github.com/ORG/REPO \
+                -p git+https://github.com/carabiner-dev/policies#sigstore/gitsign-commit-signature.hjson \
+                --signer 'sigstore::https://accounts.google.com::committer@example.com'
+            ```
+
+            Alternatively, pin the accepted signer(s) directly in the policy by
+            adding an `identities` block (sigstore `mode: regexp` lets a single
+            entry match a whole org).
+            '''
+    }
+
+    tenets: [
+        {
+            // The gitsign collector emits a commit attestation whose verification
+            // block carries the identity AMPEL matched against the supplied
+            // `--signer` / policy `identities`. Require a verified attestation
+            // whose matched signer identity (1) is set and (2) is a sigstore
+            // identity — this rejects the case where no accepted identity was
+            // supplied (an empty match set still counts as "verified") and the
+            // case where the accepted identity is a key or reference rather than
+            // a sigstore identity.
+            //
+            // The tenet reads only `verification`, so it is agnostic to the
+            // gitsign predicate body; the trust decision is AMPEL's identity
+            // match against the verified Fulcio signer.
+            id: has-verified-allowed-signer
+            predicates: { types: ["https://gitsign.sigstore.dev/predicate/git/v0.1"] }
+
+            code:
+                '''
+                predicates.exists(p,
+                    p.verification.verified &&
+                    size(p.verification.identities) > 0 &&
+                    p.verification.identities.all(i, has(i.sigstore))
+                )
+                '''
+
+            assessment: { message: "The commit is gitsign-signed by an accepted sigstore signer" }
+            error: {
+                message: "The commit is not signed by an accepted sigstore signer"
+                guidance: "The commit must carry a verified gitsign (sigstore) signature whose signer matches an accepted sigstore identity. Pass the expected identity with --signer 'sigstore::<issuer>::<identity>' (or declare it in the policy) — a key or reference identity, or no identity at all, is rejected."
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This pull request adds a new policy file for verifying gitsign (sigstore) commit signatures. The new tenet ensures that git commits are signed by an accepted sigstore identity, improving the security and compliance of commit verification.

**Gitsign commit signature verification:**

* Added `gitsign-commit-signature.hjson` defining a tenet that passes only if a commit is signed by a verified and accepted sigstore signer. The policy checks that the signer identity is present, is a sigstore identity, and matches those supplied via `--signer` or in the policy `identities` block.
* Included comprehensive documentation in the policy file, explaining how the verification works, how to use the tenet, and how to configure accepted signers.