### PR TITLE
Add new OpenEOX predicates

### DIFF
--- a/openeox/has-openeox.json
+++ b/openeox/has-openeox.json
@@ -7,7 +7,10 @@
         {
             "id": "01-openeox",
             "predicates": {
-                "types": ["https://docs.oasis-open.org/openeox/core/v1.0"]
+                "types": [
+                    "https://docs.oasis-open.org/openeox/core/v1.0",
+                    "https://docs.oasis-open.org/openeox/eox-core/v1.0"
+                ]
             },
             "code": "size(predicates) > 0",
             "assessment": {


### PR DESCRIPTION
This pull request updates the `openeox/has-openeox.json` file to expand the supported types for the "01-openeox" rule. The change ensures compatibility with both the core and eox-core OpenEOX specifications.

Specification support:

* Added `"https://docs.oasis-open.org/openeox/eox-core/v1.0"` to the list of supported `types` in the "01-openeox" rule, allowing validation against both the core and eox-core specifications.